### PR TITLE
fix: remove @rsbuild/core 0.x from peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"yaml-loader": "^0.8.1"
 	},
 	"peerDependencies": {
-		"@rsbuild/core": "0.x || 1.x"
+		"@rsbuild/core": "1.x"
 	},
 	"peerDependenciesMeta": {
 		"@rsbuild/core": {


### PR DESCRIPTION
Remove @rsbuild/core 0.x from peer dependency, now requires Rsbuild 1.x