### PR TITLE
fix: remove stale package entry fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
       "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

This PR removes stale `main` and `module` fields from `package.json` because the package already uses `exports` to define its public entry points. The removed `module` field pointed to `dist/index.mjs`, which is not included in the published package.